### PR TITLE
Implement intro fade sequence

### DIFF
--- a/galaxy_explorer/main.py
+++ b/galaxy_explorer/main.py
@@ -85,8 +85,59 @@ class Game:
             pygame.quit()
             sys.exit()
 
+    def play_intro(self):
+        """Display a starting intro with fade effects."""
+        fade_frames = int(1.5 * settings.FPS)
+        big_font = pygame.font.SysFont(None, 120)
+        text_surf = big_font.render("Zenith", True, settings.WHITE).convert_alpha()
+        text_rect = text_surf.get_rect(center=(settings.SCREEN_WIDTH // 2,
+                                              settings.SCREEN_HEIGHT // 2))
+
+        for i in range(fade_frames):
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+            alpha = int(255 * (i / fade_frames))
+            text_surf.set_alpha(alpha)
+            self.screen.fill(settings.BLACK)
+            self.screen.blit(text_surf, text_rect)
+            pygame.display.flip()
+            self.clock.tick(settings.FPS)
+
+        for i in range(fade_frames):
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+            alpha = int(255 * (1 - i / fade_frames))
+            text_surf.set_alpha(alpha)
+            self.screen.fill(settings.BLACK)
+            self.screen.blit(text_surf, text_rect)
+            pygame.display.flip()
+            self.clock.tick(settings.FPS)
+
+        overlay = pygame.Surface((settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT))
+        overlay.fill(settings.BLACK)
+        for i in range(fade_frames):
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+            if self.current_view:
+                self.current_view.update(0, pygame.mouse.get_pos(),
+                                        pygame.key.get_pressed(), self.frame_count)
+                self.current_view.render(self.screen, pygame.mouse.get_pos(),
+                                         self.frame_count)
+            alpha = int(255 * (1 - i / fade_frames))
+            overlay.set_alpha(alpha)
+            self.screen.blit(overlay, (0, 0))
+            pygame.display.flip()
+            self.clock.tick(settings.FPS)
+            self.frame_count += 1
 
     def run(self):
+        self.play_intro()
         print("Entering Main Game Loop...")
         while self.running:
             dt = self.clock.tick(settings.FPS) / 1000.0


### PR DESCRIPTION
## Summary
- add `play_intro` in `main.py` to fade 'Zenith' text in and out
- call intro sequence at the start of the game loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`