### PR TITLE
Add triangle intro sequence

### DIFF
--- a/galaxy_explorer/core/utils.py
+++ b/galaxy_explorer/core/utils.py
@@ -48,6 +48,31 @@ def draw_text(text, font_type, color, surface, x, y):
         print(f"Font '{font_type}' not available for text: {text}")
 
 
+# --- Intro Graphics ---
+def draw_shiny_triangle(surface, center, size, progress, alpha=255):
+    """Draw a neon green bordered triangle with a moving white sheen."""
+    tri_surf = pygame.Surface(surface.get_size(), pygame.SRCALPHA)
+    half = size // 2
+    pts = [
+        (center[0], center[1] - half),
+        (center[0] - half, center[1] + half),
+        (center[0] + half, center[1] + half)
+    ]
+
+    pygame.draw.polygon(tri_surf, (0, 100, 255), pts)
+    pygame.draw.polygon(tri_surf, settings.GREEN, pts, 4)
+
+    diag_len = int(math.hypot(size * 2, size * 2))
+    offset = int(-diag_len / 2 + progress * diag_len)
+    start = (center[0] - size + offset, center[1] - size)
+    end = (start[0] + diag_len, start[1] + diag_len)
+    width = max(1, size // 8)
+    pygame.draw.line(tri_surf, (255, 255, 255, 180), start, end, width)
+
+    tri_surf.set_alpha(alpha)
+    surface.blit(tri_surf, (0, 0))
+
+
 # --- Star-Field Specifics ---
 _TWINKLE_STARS_DATA = []
 

--- a/galaxy_explorer/main.py
+++ b/galaxy_explorer/main.py
@@ -95,11 +95,12 @@ class Game:
                 return True
         return False
 
-    def play_intro(self, fade_in_time=1.5, fade_out_time=1.5, game_fade_in_time=1.5):
+    def play_intro(self, fade_in_time=1.5, fade_out_time=1.5, game_fade_in_time=1.5, triangle_time=1.0):
         """Display a starting intro with optional fade durations and intro music."""
         fade_in_frames = int(fade_in_time * settings.FPS)
         fade_out_frames = int(fade_out_time * settings.FPS)
         game_fade_frames = int(game_fade_in_time * settings.FPS)
+        triangle_frames = int(triangle_time * settings.FPS)
 
         # Attempt to play the intro music if available
         try:
@@ -113,13 +114,30 @@ class Game:
         text_rect = text_surf.get_rect(center=(settings.SCREEN_WIDTH // 2,
                                               settings.SCREEN_HEIGHT // 2))
 
+        triangle_size = min(settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT) // 2
+        center = (settings.SCREEN_WIDTH // 2, settings.SCREEN_HEIGHT // 2)
+
+        for i in range(triangle_frames):
+            if self._handle_intro_events():
+                pygame.mixer.music.stop()
+                return
+            alpha = int(255 * (i / triangle_frames))
+            self.screen.fill(settings.BLACK)
+            utils.draw_shiny_triangle(self.screen, center, triangle_size,
+                                      i / triangle_frames, alpha)
+            pygame.display.flip()
+            self.clock.tick(settings.FPS)
+
         for i in range(fade_in_frames):
             if self._handle_intro_events():
                 pygame.mixer.music.stop()
                 return
             alpha = int(255 * (i / fade_in_frames))
+            tri_alpha = int(255 * (1 - i / fade_in_frames))
             text_surf.set_alpha(alpha)
             self.screen.fill(settings.BLACK)
+            utils.draw_shiny_triangle(self.screen, center, triangle_size,
+                                      i / fade_in_frames, tri_alpha)
             self.screen.blit(text_surf, text_rect)
             pygame.display.flip()
             self.clock.tick(settings.FPS)


### PR DESCRIPTION
## Summary
- animate a shiny neon triangle before showing the Zenith title
- fade out the triangle while fading in the title
- include helper to draw the shiny triangle

## Testing
- `python -m py_compile galaxy_explorer/main.py`
- `python -m py_compile galaxy_explorer/core/utils.py`
- `python - <<'EOF'
import sys, py_compile, pathlib
files=[f for f in pathlib.Path('.').rglob('*.py')]
for f in files:
    py_compile.compile(str(f), doraise=True)
print('ok')
EOF`